### PR TITLE
minor bug fix (#9)

### DIFF
--- a/include/cdsl_defs.h
+++ b/include/cdsl_defs.h
@@ -30,6 +30,7 @@ extern "C" {
  */
 #ifdef BAREMETAL
 #include "baremetal.h"
+#include <stddef.h>
 #define PRINT(...)
 #define PRINT_ERR(...)
 #define EXIT(n)

--- a/source/base_tree.c
+++ b/source/base_tree.c
@@ -6,7 +6,7 @@
  */
 
 #include "base_tree.h"
-#include "cdsl.h"
+#include "cdsl_defs.h"
 #include "arch.h"
 
 

--- a/source/cdsl_bstree.c
+++ b/source/cdsl_bstree.c
@@ -8,7 +8,7 @@
 
 #include "cdsl_bstree.h"
 #include "base_tree.h"
-#include "cdsl.h"
+#include "cdsl_defs.h"
 #include <stddef.h>
 
 

--- a/source/cdsl_hashtree.c
+++ b/source/cdsl_hashtree.c
@@ -39,7 +39,7 @@ hashNode_t* cdsl_hashtreeInsert(hashRoot_t* root, hashNode_t* node) {
 	// and old one returned as collision here
 	hashNode_t* collision  = (hashNode_t* )cdsl_nrbtreeInsert(&root->_base, &node->_base, TRUE);
 	if(collision) {
-		printf("collision\n");
+		PRINT("collision\n");
 		collision = container_of(collision, hashNode_t, _base);
 		if(STRCMP(collision->_str_key, node->_str_key)) {
 			// if key string of new item is different from collision, otherwise, discard collision

--- a/source/cdsl_spltree.c
+++ b/source/cdsl_spltree.c
@@ -5,7 +5,7 @@
  *      Author: innocentevil
  */
 
-#include "cdsl.h"
+#include "cdsl_defs.h"
 #include "cdsl_spltree.h"
 
 #define LEFT		((uint8_t) 0)

--- a/source/test/cdsl_bstree_test.c
+++ b/source/test/cdsl_bstree_test.c
@@ -5,7 +5,6 @@
  *      Author: root
  */
 
-#include "cdsl.h"
 #include "cdsl_bstree.h"
 #include "cdsl_bstree_test.h"
 #include <stdio.h>

--- a/source/test/cdsl_heap_test.c
+++ b/source/test/cdsl_heap_test.c
@@ -6,7 +6,6 @@
  */
 
 #include <stdio.h>
-#include "cdsl.h"
 #include "cdsl_heap.h"
 #include "cdsl_heap_test.h"
 #include <limits.h>

--- a/source/test/cdsl_list_test.c
+++ b/source/test/cdsl_list_test.c
@@ -7,7 +7,6 @@
 
 #include <stddef.h>
 #include <stdio.h>
-#include "cdsl.h"
 #include "cdsl_dlist.h"
 #include "cdsl_list_test.h"
 

--- a/source/test/cdsl_spltree_test.c
+++ b/source/test/cdsl_spltree_test.c
@@ -6,7 +6,6 @@
  */
 
 
-#include "cdsl.h"
 #include "cdsl_spltree.h"
 #include "cdsl_spltree_test.h"
 #include <stdio.h>


### PR DESCRIPTION
* 0.1.4 (#7)

* added unit testing code for baremetal utility

* improve hashtree collision handling.
improve test coverage
add random string sequence to be used in hashtree testing

* erroneous header inclusion is fixed

* fix dropped build dependency in 'cdsl_defs.h'