### PR TITLE
0.1.5 (#17)

### DIFF
--- a/include/cdsl_defs.h
+++ b/include/cdsl_defs.h
@@ -61,7 +61,7 @@ extern "C" {
 #endif
 
 #ifndef DECLARE_PRINTER
-#define DECLARE_PRINTER(fn) void fn(void* node)
+#define DECLARE_PRINTER(fn)    void fn(void* node)
 #endif
 
 typedef void* (*cdsl_generic_compare_t)(void*, void*);

--- a/source/test/cdsl_avltree_test.c
+++ b/source/test/cdsl_avltree_test.c
@@ -32,6 +32,14 @@ BOOL cdsl_avltreeDoTest(void) {
 			keys[i] = i;
 		cdsl_avltreeNodeInit(&node_pool[i], keys[i]);
 		cdsl_avltreeInsert(&root, &node_pool[i], FALSE);
+  }
+	if(cdsl_avltreeSize(&root) != TEST_SIZE) {
+		return FALSE;
+	}
+	avltreeNode_t* node = cdsl_avltreeLookup(&root, keys[0]);
+	if(node->key != keys[0]) {
+		return FALSE;
+	}
 
 	if(cdsl_avltreeSize(&root) != TEST_SIZE) {
 		return FALSE;
@@ -40,6 +48,7 @@ BOOL cdsl_avltreeDoTest(void) {
 	if(node->key != keys[0]) {
 		return FALSE;
 	}
+
 
 
 //	cdsl_avltreePrint(&root, avlnode_printer);

--- a/source/test/cdsl_avltree_test.c
+++ b/source/test/cdsl_avltree_test.c
@@ -32,7 +32,7 @@ BOOL cdsl_avltreeDoTest(void) {
 			keys[i] = i;
 		cdsl_avltreeNodeInit(&node_pool[i], keys[i]);
 		cdsl_avltreeInsert(&root, &node_pool[i], FALSE);
-  }
+        }
 	if(cdsl_avltreeSize(&root) != TEST_SIZE) {
 		return FALSE;
 	}
@@ -44,11 +44,6 @@ BOOL cdsl_avltreeDoTest(void) {
 	if(cdsl_avltreeSize(&root) != TEST_SIZE) {
 		return FALSE;
 	}
-	avltreeNode_t* node = cdsl_avltreeLookup(&root, keys[0]);
-	if(node->key != keys[0]) {
-		return FALSE;
-	}
-
 
 
 //	cdsl_avltreePrint(&root, avlnode_printer);


### PR DESCRIPTION
* 0.1.5 (#13) (#14)

* minor bug fix (#9)

* 0.1.4 (#7)

* added unit testing code for baremetal utility

* improve hashtree collision handling.
improve test coverage
add random string sequence to be used in hashtree testing

* erroneous header inclusion is fixed

* fix dropped build dependency in 'cdsl_defs.h'

* - simplify delete op. in plain binary search tree
- format code along the k&r style

* - working on AVL tree implmentation
- working on API document (doxygen)

* doxygen work for base_tree / avltree is done.
implementing AVL tree

* minor fix in header file (cdsl_avltree.h)

Signed-off-by: fritzprix <innocentevil0914@gmail.com>

* - add test template for avltree
- implemented AVL insert as draft

* working on avltree lookup / delete op.
working on avltree test code

* fix conflict resolution error from github web resolver